### PR TITLE
0x07cb patch 1 - Clarification des instructions de connexion GPIO pour le capteur DHT11 et amélioration de la documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Le capteur DHT11 possède trois broches principales :
 #### Étapes pour connecter le capteur DHT11 :
 1. Identifiez les broches du capteur DHT11 (VCC, DATA, GND).
 2. Connectez la broche **VCC** à une broche d'alimentation 5V ou 3.3V du Raspberry Pi.
-3. Connectez la broche **DATA** à la broche GPIO 4 (ou une autre broche GPIO si spécifiée dans le script).
+3. Connectez la broche **DATA** à la broche GPIO 4 (ou une autre broche GPIO compatible, voir encadré ci-dessous).
 4. Connectez la broche **GND** à une broche de masse (GND) du Raspberry Pi.
 5. Assurez-vous que le démon pigpio est actif sur le Raspberry Pi :
    ```bash
@@ -81,6 +81,23 @@ Le capteur DHT11 possède trois broches principales :
    ```bash
    dht11.py --temperature --humidity
    ```
+
+> **Important : Choix de la broche GPIO**
+>
+> - Le DHT11 peut être connecté à n'importe quelle broche GPIO numérique du Raspberry Pi (modèles 2, 3, 4), à condition qu'elle ne soit pas déjà utilisée par un autre périphérique ou une fonction spéciale (I2C, SPI, UART, etc.).
+> - Par convention, la broche GPIO 4 (numérotation BCM) est souvent utilisée, mais ce n'est pas une obligation.
+> - **Numérotation recommandée :** Toutes les instructions et scripts de ce projet utilisent la numérotation BCM (Broadcom), qui est la plus courante dans la documentation Raspberry Pi et dans les bibliothèques Python (pigpio, gpiozero, etc.).
+> - **À éviter :** N'utilisez pas les broches réservées à l'alimentation (5V/3.3V), à la masse (GND), ni les broches déjà utilisées pour I2C (GPIO 2/3), UART (GPIO 14/15), SPI (GPIO 10/9/11), sauf si vous savez ce que vous faites.
+> - **Exemples de GPIO compatibles (numérotation BCM) :**
+>   - GPIO 4 (par défaut)
+>   - GPIO 17
+>   - GPIO 18
+>   - GPIO 27
+>   - GPIO 22
+>   - GPIO 23
+>   - GPIO 24
+>   - GPIO 25
+> - **Astuce :** Pour éviter toute confusion, vérifiez toujours que vous utilisez la numérotation BCM (et non la numérotation physique BOARD) dans vos scripts et branchements. La plupart des bibliothèques Python utilisent BCM par défaut.
 
 > **Note** : Ce script est compatible avec les Raspberry Pi 2, 3 et 4. Il n'a pas encore été testé sur le Raspberry Pi 5, mais une adaptation est prévue pour cette plateforme dans le futur.
 


### PR DESCRIPTION
Cette pull request apporte les modifications suivantes :

- **Clarification des instructions de connexion du capteur DHT11 dans le README.md**  
  Les étapes de branchement du capteur DHT11 sur le Raspberry Pi ont été précisées.  
  Un encadré détaille désormais :
  - Les broches GPIO compatibles (numérotation BCM recommandée)
  - Les broches à éviter (alimentation, GND, I2C, SPI, UART, etc.)
  - Des exemples de GPIO utilisables
  - Un rappel sur la différence entre la numérotation BCM et BOARD

- **Ajout d’astuces pour éviter les erreurs de branchement**  
  Le README insiste sur l’importance d’utiliser la numérotation BCM, la plus courante dans les bibliothèques Python (pigpio, gpiozero…).

- **Précision sur la compatibilité matérielle**  
  Mention explicite de la compatibilité avec les Raspberry Pi 2, 3 et 4, et note sur le Pi 5.

- **Aucune modification du code source Python ou des scripts Bash**  
  Les scripts d’installation et d’utilisation restent inchangés, seule la documentation utilisateur a été enrichie pour éviter les erreurs de branchement et faciliter la prise en main.

---

**But de la PR :**  
Faciliter la connexion du capteur DHT11 pour les utilisateurs, éviter les erreurs fréquentes de branchement, et rendre la documentation plus claire et accessible.